### PR TITLE
Authnzerver API rate-limiting

### DIFF
--- a/.github/workflows/pull-req-flow.yml
+++ b/.github/workflows/pull-req-flow.yml
@@ -1,8 +1,8 @@
-name: Test authnzerver main branch and build Docker containers
+name: Test authnzerver pull request
 
 on:
-  push:
-    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
 
@@ -26,18 +26,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-
-  push_to_registry:
-    needs: build
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: waqasbhatti/authnzerver
-          tag_with_ref: true

--- a/authnzerver/cache.py
+++ b/authnzerver/cache.py
@@ -182,7 +182,7 @@ def cache_getrate(key,
     insertion inserted at key and the number of times it was incremented in
     key-counter. The rate is then:
 
-    key-counter_val/((time_now - time_insertion)/60.0)
+        key-counter_val/((time_now - time_insertion)/60.0)
 
     '''
 

--- a/authnzerver/confvars.py
+++ b/authnzerver/confvars.py
@@ -272,6 +272,22 @@ CONF = {
         'readable_from_file':False,
         'postprocess_value':None,
     },
+    'ratelimits':{
+        'env':'%s_RATELIMITS' % ENVPREFIX,
+        'cmdline':'ratelimits',
+        'type':str,
+        'default':"all:15000;user:360;session:600;apikey:720;burst:20",
+        'help':("This sets the rate limit policy for authnzerver actions. "
+                "You can specify values for all actions, user-tied actions "
+                "(based on email/user_id/IP address), session-tied actions "
+                "(based on session token/IP address), and apikey-tied actions "
+                "(based on session token/IP address). The values are in units "
+                "of max requests allowed per minute. The burst value "
+                "indicates how many requests will be allowed to come "
+                "in before rate-limits start being enforced."),
+        'readable_from_file':False,
+        'postprocess_value':None,
+    },
     'workers':{
         'env':'%s_WORKERS' % ENVPREFIX,
         'cmdline':'workers',

--- a/authnzerver/confvars.py
+++ b/authnzerver/confvars.py
@@ -162,15 +162,6 @@ CONF = {
         'readable_from_file':False,
         'postprocess_value':None,
     },
-    'cachedir':{
-        'env':'%s_CACHEDIR' % ENVPREFIX,
-        'cmdline':'cachedir',
-        'type':str,
-        'default':'/tmp/authnzerver-cache',
-        'help':('Path to the cache directory to be used.'),
-        'readable_from_file':False,
-        'postprocess_value':None,
-    },
     'debugmode':{
         'env':'%s_DEBUGMODE' % ENVPREFIX,
         'cmdline':'debugmode',

--- a/authnzerver/confvars.py
+++ b/authnzerver/confvars.py
@@ -284,7 +284,8 @@ CONF = {
                 "(based on session token/IP address). The values are in units "
                 "of max requests allowed per minute. The burst value "
                 "indicates how many requests will be allowed to come "
-                "in before rate-limits start being enforced."),
+                "in before rate-limits start being enforced. "
+                "Set this to 'none' to turn off rate-limiting entirely."),
         'readable_from_file':False,
         'postprocess_value':None,
     },

--- a/authnzerver/dictcache.py
+++ b/authnzerver/dictcache.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+# cache.py - Waqas Bhatti (waqas.afzal.bhatti@gmail.com) - Jul 2020
+# License: MIT - see the LICENSE file for the full text.
+"""This contains a simple dict-based in-memory cache.
+
+"""
+
+#############
+## IMPORTS ##
+#############
+
+import logging
+from typing import Any
+from time import monotonic
+import pickle
+from collections import namedtuple
+
+from sortedcontainers import SortedSet
+
+# get a logger
+LOGGER = logging.getLogger(__name__)
+
+
+#######################
+## sorted key object ##
+#######################
+
+SortedKey = namedtuple('SortedKey', ['inserted', 'key'])
+
+
+##################
+## CACHE OBJECT ##
+##################
+
+class DictCache:
+
+    def __init__(self, capacity=20000):
+        """
+        Initializes a cache with the given capacity.
+
+        """
+
+        self.container = {}
+        self.capacity = capacity
+        self.sortedkeys = SortedSet()
+
+    def _trim(self):
+        """
+        Removes the oldest key in the cache.
+
+        """
+        if len(self.container) > self.capacity:
+            oldest_key = self.sortedkeys.pop()
+            self.container.pop(oldest_key.key)
+
+    def size(self):
+        """
+        Returns the number of items in the cache.
+
+        """
+
+        return len(self.container)
+
+    def add(self, key, value):
+        """
+        Adds a key and sets it to the value.
+
+        If the key already exists, does nothing.
+
+        """
+
+        self._trim()
+
+        if key not in self.container:
+
+            insert_time = monotonic()
+
+            sortedkey = SortedKey(insert_time, key)
+            self.sortedkeys.add(sortedkey)
+            self.container[key] = {'value':value, 'inserted':insert_time}
+            return value
+
+        else:
+            return value
+
+    def get(self, key):
+        """
+        Gets the value of key from the cache.
+
+        """
+
+        item = self.container.get(key, None)
+        if item:
+            return item['value']
+        else:
+            return None
+
+    def set(self, key, value,
+            add_ifnotexists=True,
+            update_insertedtime=False):
+        """This sets the value of key to value and returns the new value.
+
+        If the key doesn't exist and add_ifnotexists is False, returns None. If
+        add_ifnotexists is True, adds the key to the cache and returns the
+        value.
+
+        If update_insertedtime is True, will also update the inserted time.
+
+        """
+
+        if key not in self.container and add_ifnotexists:
+            return self.add(key, value)
+
+        elif key in self.container:
+
+            if update_insertedtime:
+                insert_time = monotonic()
+                sortedkey = SortedKey(insert_time, key)
+                self.sortedkeys.add(sortedkey)
+                self.container[key] = {'value':value,'inserted':insert_time}
+
+            else:
+                self.container[key]['value'] = value
+
+            return self.container[key]['value']
+
+        else:
+            return None
+
+    def pop(self, key):
+        """
+        Pops the key from the cache.
+
+        """
+
+        item = self.container.pop(key, None)
+        if item:
+            sortedkey = SortedKey(item['inserted'], key)
+            self.sortedkeys.remove(sortedkey)
+            return item['value']
+        else:
+            return None
+
+    def delete(self, key):
+        """Deletes the key from the cache.
+
+        """
+
+        removed_item = self.pop(key)
+        if removed_item:
+            return True
+        else:
+            return False
+
+    def count(self, key):
+        """This gets the current count for a key that was previously
+        incremented/decremented.
+
+        """
+
+        counter_key = f"{key}-cachecounterkey"
+
+        if counter_key in self.container:
+            count = self.get(counter_key)
+            return count
+
+        else:
+            return 0
+
+    def increment(self, key):
+        """This increments a key by 1 every time it's called
+        and returns the new count.
+
+        If the key doesn't exist, adds it to the cache with an initial count of
+        1.
+
+        """
+
+        counter_key = f"{key}-cachecounterkey"
+
+        if counter_key in self.container:
+
+            count = self.get(counter_key)
+            updated_count = self.set(counter_key, count+1)
+            return updated_count
+
+        else:
+            return self.add(counter_key, 1)
+
+    def decrement(self, key, pop_whenzero=True):
+        """Decrements a key by 1 every time it's called.
+
+        If pop_whenzero is True, will pop the key when its count reaches zero
+        either after the current decrement or if the count has already reached
+        zero before the decrement operation will be performed.
+
+        Returns the new count after decrement or None if the key doesn't exist
+        in the cache.
+
+        """
+
+        counter_key = f"{key}-cachecounterkey"
+
+        if counter_key in self.container:
+
+            count = self.get(counter_key)
+
+            if count is not None and count == 0 and pop_whenzero:
+                self.pop(counter_key)
+                return 0
+
+            elif count is not None and count == 0:
+                return 0
+
+            elif count is not None:
+                new_count = self.set(counter_key, count-1)
+                if new_count == 0 and pop_whenzero:
+                    self.pop(counter_key)
+                    return 0
+                else:
+                    return new_count
+
+        else:
+            return None
+
+    def getrate(self, key, period_seconds):
+        """This gets the rate of increment over period (in seconds) for
+        a counter key that was incremented in the past.
+
+        """
+
+        counter_key = f"{key}-cachecounterkey"
+
+        if counter_key in self.container:
+            key_item = self.container[counter_key]
+
+            rate = ( key_item['value'] /
+                     ((monotonic() - key_item['inserted'])/period_seconds) )
+            return rate
+
+        else:
+            return 0.0
+
+    def flush(self):
+        """
+        This removes all items in the cache.
+
+        """
+
+        self.container = {}
+        self.sortedkeys = set({})
+
+    def save(self, outfile, protocol=pickle.HIGHEST_PROTOCOL):
+        """
+        This saves the current contents of the cache to disk.
+
+        The items stored must be pickleable.
+
+        """
+
+        serialized = {
+            "sortedkeys":self.sortedkeys,
+            "container":self.container
+        }
+
+        with open(outfile,'wb') as outfd:
+            pickle.dumps(serialized, outfd, protocol=protocol)
+
+    def load(self, infile):
+        """
+        This loads contents of the cache from a pickle file on disk.
+
+        """
+
+        with open(infile, 'rb') as infd:
+            deserialized = pickle.loads(infd)
+
+        self.sortedkeys = deserialized['sortedkeys']
+        self.container = deserialized['container']

--- a/authnzerver/handlers.py
+++ b/authnzerver/handlers.py
@@ -51,7 +51,6 @@ import tornado.ioloop
 from . import actions
 from .messaging import encrypt_message, decrypt_message
 from .permissions import pii_hash
-from .cache import cache_getrate, cache_increment
 
 
 #########################
@@ -164,17 +163,18 @@ class AuthHandler(tornado.web.RequestHandler):
         """
 
         # increment the global request each time
-        all_reqcount = cache_increment(
+        all_reqcount = self.cacheobj.increment(
             "all_request_count",
-            cacheobj=self.cacheobj
         )
 
         # check the global request rate
         if all_reqcount > self.ratelimits['burst']:
 
-            all_reqrate, all_reqcount, all_req_t0 = cache_getrate(
-                "all_request_count",
-                cacheobj=self.cacheobj
+            all_reqrate, all_reqcount, all_req_t0, all_req_tnow = (
+                self.cacheobj.getrate(
+                    "all_request_count",
+                    60.0,
+                )
             )
 
             if all_reqrate > self.ratelimits['all']:
@@ -213,16 +213,17 @@ class AuthHandler(tornado.web.RequestHandler):
 
             user_cache_key = f"user-request-{user_cache_token}"
 
-            user_reqcount = cache_increment(
+            user_reqcount = self.cacheobj.increment(
                 user_cache_key,
-                cacheobj=self.cacheobj
             )
 
             if user_reqcount > self.ratelimits["user"]:
 
-                user_reqrate, user_reqcount, user_req_t0 = cache_getrate(
-                    user_cache_key,
-                    cacheobj=self.cacheobj
+                user_reqrate, user_reqcount, user_req_t0, user_req_tnow = (
+                    self.cacheobj.getrate(
+                        user_cache_key,
+                        60.0,
+                    )
                 )
 
                 if user_reqrate > self.ratelimits['user']:
@@ -258,17 +259,19 @@ class AuthHandler(tornado.web.RequestHandler):
 
             session_cache_key = f"session-request-{session_cache_token}"
 
-            session_reqcount = cache_increment(
+            session_reqcount = self.cacheobj.increment(
                 session_cache_key,
-                cacheobj=self.cacheobj
             )
 
             if session_reqcount > self.ratelimits["session"]:
 
-                session_reqrate, session_reqcount, session_req_t0 = (
-                    cache_getrate(
+                (session_reqrate,
+                 session_reqcount,
+                 session_req_t0,
+                 session_req_tnow) = (
+                    self.cacheobj.getrate(
                         session_cache_key,
-                        cacheobj=self.cacheobj
+                        60.0,
                     )
                 )
 
@@ -309,17 +312,19 @@ class AuthHandler(tornado.web.RequestHandler):
 
             apikey_cache_key = f"apikey-request-{apikey_cache_token}"
 
-            apikey_reqcount = cache_increment(
+            apikey_reqcount = self.cacheobj.increment(
                 apikey_cache_key,
-                cacheobj=self.cacheobj
             )
 
             if apikey_reqcount > self.ratelimits["apikey"]:
 
-                apikey_reqrate, apikey_reqcount, apikey_req_t0 = (
-                    cache_getrate(
+                (apikey_reqrate,
+                 apikey_reqcount,
+                 apikey_req_t0,
+                 apikey_req_tnow) = (
+                    self.cacheobj.getrate(
                         apikey_cache_key,
-                        cacheobj=self.cacheobj
+                        60.0,
                     )
                 )
 

--- a/authnzerver/handlers.py
+++ b/authnzerver/handlers.py
@@ -51,6 +51,7 @@ import tornado.ioloop
 from . import actions
 from .messaging import encrypt_message, decrypt_message
 from .permissions import pii_hash
+from .cache import cache_getrate, cache_increment
 
 
 #########################
@@ -130,6 +131,7 @@ class AuthHandler(tornado.web.RequestHandler):
     def initialize(self,
                    config,
                    executor,
+                   cacheobj,
                    failed_passchecks):
         '''
         This sets up stuff.
@@ -148,9 +150,193 @@ class AuthHandler(tornado.web.RequestHandler):
         self.emailpass = self.config.emailpass
 
         self.executor = executor
+        self.cacheobj = cacheobj
         self.failed_passchecks = failed_passchecks
 
         self.allowed_hosts_regex = config.allowed_hosts_regex
+        self.ratelimits = config.ratelimits
+
+    def ratelimit_request(self, reqid, request_type, request_body):
+        """
+        This rate-limits the request based on the request type and the
+        set ratelimits passed in the config object.
+
+        """
+
+        # increment the global request each time
+        all_reqcount = cache_increment(
+            "all_request_count",
+            cacheobj=self.cacheobj
+        )
+
+        # check the global request rate
+        if all_reqcount > self.ratelimits['burst']:
+
+            all_reqrate, all_reqcount, all_req_t0 = cache_getrate(
+                "all_request_count",
+                cacheobj=self.cacheobj
+            )
+
+            if all_reqrate > self.ratelimits['all']:
+                LOGGER.error(
+                    "[%s] request '%s' is being rate-limited. "
+                    "Cache token: 'all_request_count', count: %s. "
+                    "Rate: %.3f > limit specified for '%s': %s"
+                    % (reqid,
+                       request_type,
+                       all_reqcount,
+                       all_reqrate,
+                       'all',
+                       self.ratelimits['all'])
+                )
+                raise tornado.web.HTTPError(status_code=429)
+
+        # check the user- prefixed request
+        if request_type.startswith("user-"):
+
+            user_cache_token = (
+                request_body.get("email", None) or
+                request_body.get("user_id", None) or
+                request_body.get("session_token", None) or
+                request_body.get("ip_address", None) or
+                request_body.get("email_address", None)
+            )
+
+            # drop all requests that try to get around rate-limiting
+            if not user_cache_token:
+                LOGGER.error(
+                    "[%s] request: '%s' is missing a payload value "
+                    "needed to calculate rate, dropping this request."
+                    % (self.reqid, request_type)
+                )
+                raise tornado.web.HTTPError(status_code=400)
+
+            user_cache_key = f"user-request-{user_cache_token}"
+
+            user_reqcount = cache_increment(
+                user_cache_key,
+                cacheobj=self.cacheobj
+            )
+
+            if user_reqcount > self.ratelimits["user"]:
+
+                user_reqrate, user_reqcount, user_req_t0 = cache_getrate(
+                    user_cache_key,
+                    cacheobj=self.cacheobj
+                )
+
+                if user_reqrate > self.ratelimits['user']:
+                    LOGGER.error(
+                        "[%s] request '%s' is being rate-limited. "
+                        "Cache token: '%s', count: %s. "
+                        "Rate: %.3f > limit specified for '%s': %s"
+                        % (reqid,
+                           request_type,
+                           pii_hash(user_cache_key, self.pii_salt),
+                           user_reqcount,
+                           user_reqrate,
+                           'user',
+                           self.ratelimits['user'])
+                    )
+                    raise tornado.web.HTTPError(status_code=429)
+
+        # check the session- prefixed request
+        if request_type.startswith("session-"):
+
+            session_cache_token = (
+                request_body.get("user_id", None) or
+                request_body.get("session_token", None) or
+                request_body.get("ip_address", None)
+            )
+            if not session_cache_token:
+                LOGGER.error(
+                    "[%s] request: '%s' is missing a payload value "
+                    "needed to calculate rate, dropping this request."
+                    % (self.reqid, request_type)
+                )
+                raise tornado.web.HTTPError(status_code=400)
+
+            session_cache_key = f"session-request-{session_cache_token}"
+
+            session_reqcount = cache_increment(
+                session_cache_key,
+                cacheobj=self.cacheobj
+            )
+
+            if session_reqcount > self.ratelimits["session"]:
+
+                session_reqrate, session_reqcount, session_req_t0 = (
+                    cache_getrate(
+                        session_cache_key,
+                        cacheobj=self.cacheobj
+                    )
+                )
+
+                if session_reqrate > self.ratelimits['session']:
+                    LOGGER.error(
+                        "[%s] request '%s' is being rate-limited. "
+                        "Cache token: '%s', count: %s. "
+                        "Rate: %.3f > limit specified for '%s': %s"
+                        % (reqid,
+                           request_type,
+                           pii_hash(session_cache_key, self.pii_salt),
+                           session_reqcount,
+                           session_reqrate,
+                           'session',
+                           self.ratelimits['session'])
+                    )
+                    raise tornado.web.HTTPError(status_code=429)
+
+        # check the apikey- prefixed request
+        if request_type.startswith("apikey-"):
+
+            # handle API key issuance
+            apikey_cache_token = (
+                request_body.get("ip_address", None)
+            )
+            # handle all other API key actions
+            if not apikey_cache_token and request_body.get("apikey_dict"):
+                apikey_cache_token = request_body["apikey_dict"].get("user_id",
+                                                                     None)
+
+            if not apikey_cache_token:
+                LOGGER.error(
+                    "[%s] request: '%s' is missing a payload value "
+                    "needed to calculate rate, dropping this request."
+                    % (self.reqid, request_type)
+                )
+                raise tornado.web.HTTPError(status_code=400)
+
+            apikey_cache_key = f"apikey-request-{apikey_cache_token}"
+
+            apikey_reqcount = cache_increment(
+                apikey_cache_key,
+                cacheobj=self.cacheobj
+            )
+
+            if apikey_reqcount > self.ratelimits["apikey"]:
+
+                apikey_reqrate, apikey_reqcount, apikey_req_t0 = (
+                    cache_getrate(
+                        apikey_cache_key,
+                        cacheobj=self.cacheobj
+                    )
+                )
+
+                if apikey_reqrate > self.ratelimits['apikey']:
+                    LOGGER.error(
+                        "[%s] request '%s' is being rate-limited. "
+                        "Cache token: '%s', count: %s. "
+                        "Rate: %.3f > limit specified for '%s': %s"
+                        % (reqid,
+                           request_type,
+                           pii_hash(apikey_cache_key, self.pii_salt),
+                           apikey_reqcount,
+                           apikey_reqrate,
+                           'apikey',
+                           self.ratelimits['apikey'])
+                    )
+                    raise tornado.web.HTTPError(status_code=429)
 
     async def send_response(self, response, reqid):
         """
@@ -191,6 +377,10 @@ class AuthHandler(tornado.web.RequestHandler):
             self.write(f"HTTP {status_code}: Could not service this request "
                        f"because of invalid request authentication token or "
                        f"violation of host restriction.")
+        elif status_code == 429:
+            self.set_header("Retry-After", "180")
+            self.write(f"HTTP {status_code}: Could not service this request "
+                       f"because the set rate limit has been exceeded.")
         else:
             self.write(f"HTTP {status_code}: Could not service this request.")
 
@@ -203,9 +393,9 @@ class AuthHandler(tornado.web.RequestHandler):
 
         '''
 
+        # check the host
         ipcheck = check_header_host(self.allowed_hosts_regex,
                                     self.request.host)
-
         if not ipcheck:
             LOGGER.warning(
                 "Invalid host in request header: '%s' "
@@ -214,24 +404,29 @@ class AuthHandler(tornado.web.RequestHandler):
             )
             raise tornado.web.HTTPError(status_code=401)
 
+        # decrypt the request
         payload = decrypt_message(self.request.body, self.fernet_secret)
         if not payload:
             raise tornado.web.HTTPError(status_code=401)
 
+        # ignore all requests for echo to this handler
         if payload['request'] == 'echo':
             LOGGER.error("This handler can't echo things.")
             raise tornado.web.HTTPError(status_code=400)
 
-        # if we successfully got past host and decryption validation, then
-        # process the request
-        try:
+        # get the request ID
+        reqid = payload.get('reqid')
+        if reqid is None:
+            raise ValueError("No request ID provided. "
+                             "Ignoring this request.")
 
-            # get the request ID
-            # this is an integer
-            reqid = payload.get('reqid')
-            if reqid is None:
-                raise ValueError("No request ID provided. "
-                                 "Ignoring this request.")
+        # rate limit the request
+        if self.ratelimits:
+            self.ratelimit_request(reqid, payload['request'], payload['body'])
+
+        # if we successfully got past host, decryption, rate-limit validation,
+        # then process the request
+        try:
 
             #
             # dispatch the action handler function
@@ -265,8 +460,7 @@ class AuthHandler(tornado.web.RequestHandler):
             # this case, we'll apply backoff to slow down repeated failed
             # passwords
             #
-            passcheck_requests = {'user-login',
-                                  'user-passcheck-nosession'}
+            passcheck_requests = {'user-login', 'user-passcheck-nosession'}
 
             if (payload['request'] in passcheck_requests and
                 response['success'] is False):

--- a/authnzerver/main.py
+++ b/authnzerver/main.py
@@ -32,8 +32,9 @@ import time
 import re
 from functools import partial
 
-from diskcache import FanoutCache
 from sqlalchemy.exc import IntegrityError
+
+from . import dictcache
 
 
 # setup signal trapping on SIGINT
@@ -193,7 +194,6 @@ def main():
 
     from .handlers import AuthHandler
     from .debughandler import EchoHandler
-    from . import cache
     from . import actions
 
     ###################
@@ -335,13 +335,8 @@ def main():
     ## SET UP CACHE OBJECT FOR RATE-LIMITING ##
     ###########################################
 
-    # clear cache
-    cacheobj = FanoutCache(cachedir, timeout=0.3)
-    removed_items = cache.cache_flush(
-        cacheobj=cacheobj
-    )
-    LOGGER.info('Removed %s stale items from authnzerver cache.' %
-                removed_items)
+    # initialize the cache
+    cacheobj = dictcache.DictCache()
 
     ###################
     ## HANDLER SETUP ##

--- a/authnzerver/main.py
+++ b/authnzerver/main.py
@@ -263,10 +263,6 @@ def main():
     basedir = loaded_config.basedir
     LOGGER.info("The server's base directory is: %s" % os.path.abspath(basedir))
 
-    cachedir = loaded_config.cachedir
-    LOGGER.info("The server's cache directory is: %s" %
-                os.path.abspath(cachedir))
-
     port = loaded_config.port
     listen = loaded_config.listen
     sessionexpiry = loaded_config.sessionexpiry

--- a/authnzerver/tests/test_confload.py
+++ b/authnzerver/tests/test_confload.py
@@ -48,7 +48,6 @@ def generate_envfile(
         filepath,
         authdb=None,
         basedir=None,
-        cachedir=None,
         debugmode=None,
         listen=None,
         permissions=None,
@@ -72,7 +71,6 @@ def generate_envfile(
                 f"""\
                 AUTHNZERVER_AUTHDB={authdb}
                 AUTHNZERVER_BASEDIR={basedir}
-                AUTHNZERVER_CACHEDIR={cachedir}
                 AUTHNZERVER_DEBUGMODE={debugmode}
                 AUTHNZERVER_LISTEN={listen}
                 AUTHNZERVER_PERMISSIONS={permissions}
@@ -146,8 +144,6 @@ def test_load_config_from_env_filesecret(monkeypatch, tmpdir):
                        "sqlite:///test/db/path")
     monkeypatch.setenv("AUTHNZERVER_BASEDIR",
                        "/test/base/dir")
-    monkeypatch.setenv("AUTHNZERVER_CACHEDIR",
-                       "/test/authnzerver/cachedir")
     monkeypatch.setenv("AUTHNZERVER_DEBUGMODE",
                        "0")
     monkeypatch.setenv("AUTHNZERVER_LISTEN",
@@ -180,7 +176,6 @@ def test_load_config_from_env_filesecret(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == "sqlite:///test/db/path"
     assert loaded_config.basedir == "/test/base/dir"
-    assert loaded_config.cachedir == "/test/authnzerver/cachedir"
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '127.0.0.1'
 
@@ -219,8 +214,6 @@ def test_load_config_from_env_textsecret(monkeypatch, tmpdir):
                        "sqlite:///test/db/path")
     monkeypatch.setenv("AUTHNZERVER_BASEDIR",
                        "/test/base/dir")
-    monkeypatch.setenv("AUTHNZERVER_CACHEDIR",
-                       "/test/authnzerver/cachedir")
     monkeypatch.setenv("AUTHNZERVER_DEBUGMODE",
                        "0")
     monkeypatch.setenv("AUTHNZERVER_LISTEN",
@@ -253,7 +246,6 @@ def test_load_config_from_env_textsecret(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == "sqlite:///test/db/path"
     assert loaded_config.basedir == "/test/base/dir"
-    assert loaded_config.cachedir == "/test/authnzerver/cachedir"
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '127.0.0.1'
 
@@ -315,7 +307,6 @@ def test_load_config_from_options(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == 'sqlite:///path/to/auth-db-opt'
     assert loaded_config.basedir == '/path/to/basedir-opt'
-    assert loaded_config.cachedir == '/tmp/authnzerver-cache'
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '192.168.1.1'
 
@@ -359,7 +350,6 @@ def test_load_config_from_envfile_filesecret(monkeypatch, tmpdir):
         tmpdir,
         authdb='sqlite:///path/to/authdb-envfile',
         basedir='/path/to/basedir-envfile',
-        cachedir='/tmp/authnzerver/cachedir-envfile',
         debugmode=0,
         listen='10.0.0.10',
         permissions=permissions_json,
@@ -381,7 +371,6 @@ def test_load_config_from_envfile_filesecret(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == "sqlite:///path/to/authdb-envfile"
     assert loaded_config.basedir == "/path/to/basedir-envfile"
-    assert loaded_config.cachedir == "/tmp/authnzerver/cachedir-envfile"
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '10.0.0.10'
 
@@ -425,7 +414,6 @@ def test_load_config_from_envfile_textsecret(monkeypatch, tmpdir):
         tmpdir,
         authdb='sqlite:///path/to/authdb-envfile',
         basedir='/path/to/basedir-envfile',
-        cachedir='/tmp/authnzerver/cachedir-envfile',
         debugmode=0,
         listen='10.0.0.10',
         permissions=permissions_json,
@@ -447,7 +435,6 @@ def test_load_config_from_envfile_textsecret(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == "sqlite:///path/to/authdb-envfile"
     assert loaded_config.basedir == "/path/to/basedir-envfile"
-    assert loaded_config.cachedir == "/tmp/authnzerver/cachedir-envfile"
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '10.0.0.10'
 
@@ -500,7 +487,6 @@ def test_load_config_env_and_defaults(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == "sqlite:///test/db/path"
     assert loaded_config.basedir == os.getcwd()
-    assert loaded_config.cachedir == '/tmp/authnzerver-cache'
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '127.0.0.1'
 
@@ -555,7 +541,6 @@ def test_load_config_options_and_defaults(monkeypatch, tmpdir):
 
     assert loaded_config.authdb == 'sqlite:///path/to/auth-db-opt'
     assert loaded_config.basedir == os.getcwd()
-    assert loaded_config.cachedir == '/tmp/authnzerver-cache'
     assert loaded_config.debugmode == 0
     assert loaded_config.listen == '192.168.1.1'
 

--- a/authnzerver/tests/test_server_ratelimits.py
+++ b/authnzerver/tests/test_server_ratelimits.py
@@ -1,0 +1,145 @@
+'''test_server_ratelimits.py -
+   Waqas Bhatti (waqas.afzal.bhatti@gmail.com) - Mar 2020
+License: MIT. See the LICENSE file for details.
+
+This tests the rate-limiting for a running authnzerver.
+
+'''
+
+import secrets
+import subprocess
+import requests
+import os.path
+import time
+from datetime import datetime, timedelta
+from collections import Counter
+
+from pytest import mark, approx
+
+from authnzerver.autosetup import autogen_secrets_authdb
+from authnzerver.messaging import encrypt_message
+
+
+@mark.skipif(
+    os.environ.get("GITHUB_WORKFLOW", None) is not None,
+    reason="github doesn't allow server tests probably"
+)
+def test_ratelimits(monkeypatch, tmpdir):
+    '''
+    This tests if the server does rate-limiting correctly.
+
+    '''
+
+    # the basedir will be the pytest provided temporary directory
+    basedir = str(tmpdir)
+
+    # we'll make the auth DB and secrets file first
+    authdb_path, creds, secrets_file, salt_file, env_file = (
+        autogen_secrets_authdb(
+            basedir,
+            interactive=False
+        )
+    )
+
+    # read in the secrets file for the secret
+    with open(secrets_file,'r') as infd:
+        secret = infd.read().strip('\n')
+
+    # read in the salts file for the salt
+    with open(salt_file,'r') as infd:
+        salt = infd.read().strip('\n')
+
+    # read the creds file so we can try logging in
+    with open(creds,'r') as infd:
+        useremail, password = infd.read().strip('\n').split()
+
+    # get a temp directory
+    tmpdir = os.path.join('/tmp', 'authnzrv-%s' % secrets.token_urlsafe(8))
+
+    server_listen = '127.0.0.1'
+    server_port = '18158'
+
+    # set up the environment
+    monkeypatch.setenv("AUTHNZERVER_AUTHDB", authdb_path)
+    monkeypatch.setenv("AUTHNZERVER_BASEDIR", basedir)
+    monkeypatch.setenv("AUTHNZERVER_CACHEDIR", tmpdir)
+    monkeypatch.setenv("AUTHNZERVER_DEBUGMODE", "0")
+    monkeypatch.setenv("AUTHNZERVER_LISTEN", server_listen)
+    monkeypatch.setenv("AUTHNZERVER_PORT", server_port)
+    monkeypatch.setenv("AUTHNZERVER_SECRET", secret)
+    monkeypatch.setenv("AUTHNZERVER_PIISALT", salt)
+    monkeypatch.setenv("AUTHNZERVER_SESSIONEXPIRY", "60")
+    monkeypatch.setenv("AUTHNZERVER_WORKERS", "1")
+    monkeypatch.setenv("AUTHNZERVER_EMAILSERVER", "smtp.test.org")
+    monkeypatch.setenv("AUTHNZERVER_EMAILPORT", "25")
+    monkeypatch.setenv("AUTHNZERVER_EMAILUSER", "testuser")
+    monkeypatch.setenv("AUTHNZERVER_EMAILPASS", "testpass")
+
+    # set the session request rate-limit to 120 per 60 seconds
+    monkeypatch.setenv("AUTHNZERVER_RATELIMITS",
+                       "all:15000;user:360;session:120;apikey:720;burst:20")
+
+    # launch the server subprocess
+    p = subprocess.Popen("authnzrv", shell=True)
+
+    # wait 2.5 seconds for the server to start
+    time.sleep(2.5)
+
+    try:
+
+        #
+        # 1. hit the server with 300 session-new requests
+        #
+        nreqs = 300
+
+        resplist = []
+        for req_ind in range(1,nreqs+1):
+
+            # create a new anonymous session token
+            session_payload = {
+                'user_id':2,
+                'user_agent':'Mozzarella Killerwhale',
+                'expires':datetime.utcnow()+timedelta(hours=1),
+                'ip_address': '1.1.1.1',
+                'extra_info_json':{'pref_datasets_always_private':True}
+            }
+
+            request_dict = {'request':'session-new',
+                            'body':session_payload,
+                            'reqid':req_ind}
+
+            encrypted_request = encrypt_message(request_dict, secret)
+
+            # send the request to the authnzerver
+            resp = requests.post(
+                'http://%s:%s' % (server_listen, server_port),
+                data=encrypted_request,
+                timeout=1.0
+            )
+            resplist.append(resp.status_code)
+
+        # now check if we have about the right number of successful requests
+        # should be around 120 after which we get all 429s
+        respcounter = Counter(resplist)
+        assert respcounter[200]/nreqs == approx(120/nreqs, rel=0.01)
+        assert respcounter[429]/nreqs == approx(180/nreqs, rel=0.01)
+
+        #
+        # kill the server at the end
+        #
+
+    finally:
+
+        p.kill()
+        try:
+            p.communicate(timeout=1.0)
+            p.kill()
+        except Exception:
+            pass
+
+        # make sure to kill authnzrv on some Linux machines.  use lsof and the
+        # port number to find the remaining authnzrv processes and kill them
+        subprocess.call(
+            "lsof | grep 18158 | awk '{ print $2 }' | sort | uniq | xargs kill",
+            shell=True
+        )

--- a/deploy/authnzerver-environ.conf
+++ b/deploy/authnzerver-environ.conf
@@ -4,8 +4,7 @@ AUTHNZERVER_LISTEN=127.0.0.1
 AUTHNZERVER_ALLOWEDHOSTS=localhost;127.0.0.1
 AUTHNZERVER_WORKERS=4
 
-# cache and base directory locations
-AUTHNZERVER_CACHEDIR=/tmp/authnzerver-cache
+# base directory locations
 AUTHNZERVER_BASEDIR=directory/where/authnzrv/is/started
 
 # secret token, PII salt, and authentication DB URL

--- a/deploy/authnzerver-environ.conf
+++ b/deploy/authnzerver-environ.conf
@@ -1,7 +1,7 @@
 # listen address, port settings, allowed hosts, and workers
 AUTHNZERVER_PORT=13141
 AUTHNZERVER_LISTEN=127.0.0.1
-AUTHNZERVER_ALLOWEDHOSTS="localhost;127.0.0.1"
+AUTHNZERVER_ALLOWEDHOSTS=localhost;127.0.0.1
 AUTHNZERVER_WORKERS=4
 
 # cache and base directory locations
@@ -17,7 +17,10 @@ AUTHNZERVER_AUTHDB=
 AUTHNZERVER_SESSIONEXPIRY=30
 AUTHNZERVER_USERLOCKTRIES=10
 AUTHNZERVER_USERLOCKTIME=3600
-AUTHNZERVER_PASSPOLICY="min_pass_length:12;max_unsafe_similarity:50"
+AUTHNZERVER_PASSPOLICY=min_pass_length:12;max_unsafe_similarity:50
+
+# API rate limits
+AUTHNZERVER_RATELIMITS=all:15000;user:360;session:600;apikey:720;burst:20
 
 # permissions model JSON
 AUTHNZERVER_PERMISSIONS=path/to/default-permissions-model.json

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -68,11 +68,6 @@ cmdline: ``--basedir``, env: ``AUTHNZERVER_BASEDIR``
 The base directory containing secret files and the auth DB. (*default:*
 directory the server is launched in)
 
-cmdline: ``--cachedir``, env: ``AUTHNZERVER_CACHEDIR``
-------------------------------------------------------
-
-Path to the cache directory to be used.(*default:* ``/tmp/authnzerver-cache``)
-
 cmdline: ``--confvars``, env: None
 ----------------------------------
 
@@ -354,7 +349,6 @@ service.
           AUTHNZERVER_ALLOWEDHOSTS: authnzerver
           AUTHNZERVER_AUTHDB: "sqlite:////home/authnzerver/basedir/.authdb.sqlite"
           AUTHNZERVER_BASEDIR: "/home/authnzerver/basedir"
-          AUTHNZERVER_CACHEDIR: "/tmp/authnzerver-cache"
           AUTHNZERVER_DEBUGMODE: 0
           AUTHNZERVER_LISTEN: "0.0.0.0"
           AUTHNZERVER_PORT: 13431

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -128,7 +128,22 @@ cmdline: ``--passpolicy``, env: ``AUTHNZERVER_PASSPOLICY``
 This sets the minimum number of characters required for passwords, and the
 maximum allowed string similarity (out of 100) between the password and unsafe
 items like the server's domain name, the user's own email address, or their full
-name. (*default:* ``min_pass_length:12;max_unsafe_similarity:50``)
+name. This parameter is specified as key:value pairs separated by a
+semicolon. (*default:* ``min_pass_length:12;max_unsafe_similarity:50``)
+
+cmdline: ``--ratelimits``, env: ``AUTHNZERVER_RATELIMITS``
+----------------------------------------------------------
+
+This sets the rate limit policy for authnzerver actions. This parameter is
+specified as key:value pairs separated by a semicolon. You can specify values
+for all actions in the ``all`` key, user-tied actions (based on email/user_id/IP
+address) in the ``user`` key, session-tied actions (based on session_token/IP
+address) in the ``session`` key, and apikey-tied actions (based on
+session_token/IP address) in the ``apikey`` key. The ``burst`` key indicates how
+many requests will be allowed to come in before rate-limits start being
+enforced. All values are in units of max requests allowed per minute. Set this
+parameter to the string 'none' to turn off rate-limiting entirely. (*default:*
+``all:15000;user:360;session:600;apikey:720;burst:20``).
 
 cmdline: ``--permissions``, env: ``AUTHNZERVER_PERMISSIONS``
 ------------------------------------------------------------
@@ -357,6 +372,7 @@ service.
           AUTHNZERVER_EMAILSENDER: "Authnzerver <authnzerver@localhost>"
           AUTHNZERVER_TLSCERTFILE:
           AUTHNZERVER_TLSCERTKEY:
+          AUTHNZERVER_RATELIMITS: "all:15000;user:360;session:600;apikey:720;burst:20"
 
 Some things to note about the snippet:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ diskcache>=3.0.6
 uvloop>=0.11.0
 confusable_homoglyphs>=3.2.0
 requests>=2.22
+sortedcontainers>=2.2.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ argon2-cffi>=18.3.0
 diskcache>=3.0.6
 uvloop>=0.11.0
 confusable_homoglyphs>=3.2.0
+sortedcontainers>=2.2.2
 pytest>=5.0
 requests-mock>=1.7.0
 aiosmtpd>=1.2


### PR DESCRIPTION
This PR adds rate-limiting to the authnzerver's own API.

This is controlled by the --ratelimit or AUTHNZERVER_RATELIMIT environment variable. From the docs:

> This sets the rate limit policy for authnzerver actions. This parameter is specified as key:value pairs separated by a semicolon. You can specify values for all actions in the `all` key, user-tied actions (based on email/user_id/IP address) in the `user` key, session-tied actions (based on session_token/IP address) in the `session` key, and apikey-tied actions (based on session_token/IP address) in the `apikey` key. The `burst` key indicates how many requests will be allowed to come in before rate-limits start being enforced. All values are in units of max requests allowed per minute. Set this parameter to the string 'none' to turn off rate-limiting entirely. (default: `all:15000;user:360;session:600;apikey:720;burst:20`).

At the moment, just checking the cache for each request slows down very fast requests (e.g. session creation) by about an order of magnitude: ~3 ms -> ~30 ms. Will try using an in-memory cache instead to see if that helps and merge this PR then.