### PR TITLE
Add key TTLs to dictcache, add tests, update counter API

### DIFF
--- a/authnzerver/dictcache.py
+++ b/authnzerver/dictcache.py
@@ -10,7 +10,11 @@
 #############
 
 import logging
-from time import monotonic
+
+# normally we'd use monotonic(), but we use time() because
+# we want to be able to preserve the cache expiries across
+# saves/loads of the cache to/from disk
+from time import time
 import pickle
 from collections import namedtuple
 from hashlib import blake2b
@@ -63,7 +67,7 @@ class DictCache:
 
         """
 
-        current_time = monotonic()
+        current_time = time()
         exp_indices_now = self.expirable_key_ttls.bisect_left(
             current_time
         )
@@ -96,12 +100,12 @@ class DictCache:
 
     def time(self):
         """
-        Returns the cache's current monotonic time counter.
+        Returns the cache's current time time counter.
 
         """
         self._expire()
 
-        return monotonic()
+        return time()
 
     def size(self):
         """
@@ -135,7 +139,7 @@ class DictCache:
 
         if key not in self.container:
 
-            insert_time = monotonic()
+            insert_time = time()
 
             sortedkey = SortedKey(insert_time, key)
             self.sortedkeys.add(sortedkey)
@@ -309,7 +313,7 @@ class DictCache:
 
         if counter_key in self.container:
             key_item = self.container[counter_key]
-            tnow = monotonic()
+            tnow = time()
             rate = ( key_item['value'] /
                      ((tnow - key_item['inserted'])/period_seconds) )
 

--- a/authnzerver/ratelimit.py
+++ b/authnzerver/ratelimit.py
@@ -64,17 +64,22 @@ class RateLimitMixin:
         """
 
         # increment the global request each time
-        all_reqcount = self.cacheobj.increment(
+        all_reqcount = self.cacheobj.counter_increment(
             "all_request_count",
         )
 
         # check the global request rate
         if all_reqcount > self.ratelimits['burst']:
 
-            all_reqrate, all_reqcount, all_req_t0, all_req_tnow = (
-                self.cacheobj.getrate(
+            (all_reqrate,
+             all_reqcount,
+             all_reqcount0,
+             all_req_tnow,
+             all_req_t0) = (
+                self.cacheobj.counter_rate(
                     "all_request_count",
                     60.0,
+                    return_allinfo=True
                 )
             )
 
@@ -120,16 +125,21 @@ class RateLimitMixin:
 
             user_cache_key = f"user-request-{user_cache_token}"
 
-            user_reqcount = self.cacheobj.increment(
+            user_reqcount = self.cacheobj.counter_increment(
                 user_cache_key,
             )
 
             if user_reqcount > self.ratelimits["burst"]:
 
-                user_reqrate, user_reqcount, user_req_t0, user_req_tnow = (
-                    self.cacheobj.getrate(
+                (user_reqrate,
+                 user_reqcount,
+                 user_reqcount0,
+                 user_req_tnow,
+                 user_req_t0) = (
+                    self.cacheobj.counter_rate(
                         user_cache_key,
                         60.0,
+                        return_allinfo=True
                     )
                 )
 
@@ -166,7 +176,7 @@ class RateLimitMixin:
 
             session_cache_key = f"session-request-{session_cache_token}"
 
-            session_reqcount = self.cacheobj.increment(
+            session_reqcount = self.cacheobj.counter_increment(
                 session_cache_key,
             )
 
@@ -174,11 +184,13 @@ class RateLimitMixin:
 
                 (session_reqrate,
                  session_reqcount,
-                 session_req_t0,
-                 session_req_tnow) = (
-                    self.cacheobj.getrate(
+                 session_reqcount0,
+                 session_req_tnow,
+                 session_req_t0) = (
+                    self.cacheobj.counter_rate(
                         session_cache_key,
                         60.0,
+                        return_allinfo=True
                     )
                 )
 
@@ -219,7 +231,7 @@ class RateLimitMixin:
 
             apikey_cache_key = f"apikey-request-{apikey_cache_token}"
 
-            apikey_reqcount = self.cacheobj.increment(
+            apikey_reqcount = self.cacheobj.counter_increment(
                 apikey_cache_key,
             )
 
@@ -227,11 +239,13 @@ class RateLimitMixin:
 
                 (apikey_reqrate,
                  apikey_reqcount,
-                 apikey_req_t0,
-                 apikey_req_tnow) = (
-                    self.cacheobj.getrate(
+                 apikey_reqcount0,
+                 apikey_req_now,
+                 apikey_req_t0) = (
+                    self.cacheobj.counter_rate(
                         apikey_cache_key,
                         60.0,
+                        return_allinfo=True
                     )
                 )
 
@@ -258,7 +272,7 @@ class RateLimitMixin:
             internal_cache_token = f"{request_type}-{self.request.remote_ip}"
             internal_cache_key = f"internal-request-{internal_cache_token}"
 
-            internal_reqcount = self.cacheobj.increment(
+            internal_reqcount = self.cacheobj.counter_increment(
                 internal_cache_key,
             )
 
@@ -267,11 +281,13 @@ class RateLimitMixin:
 
                 (internal_reqrate,
                  internal_reqcount,
-                 internal_req_t0,
-                 internal_req_tnow) = (
-                    self.cacheobj.getrate(
+                 internal_reqcount0,
+                 internal_req_tnow,
+                 internal_req_t0) = (
+                    self.cacheobj.counter_rate(
                         internal_cache_key,
                         60.0,
+                        return_allinfo=True
                     )
                 )
 

--- a/authnzerver/tests/test_dictcache.py
+++ b/authnzerver/tests/test_dictcache.py
@@ -1,0 +1,336 @@
+"""
+This includes tests for the dictcache in-memory store.
+
+"""
+
+import time
+
+import pytest
+
+from authnzerver.dictcache import DictCache
+
+
+@pytest.fixture(scope="function")
+def dictcache_obj():
+    """
+    This is a fixture that returns a DictCache object.
+
+    """
+
+    return DictCache(capacity=1000)
+
+
+#
+# basic tests
+#
+
+def test_add_key(dictcache_obj):
+    """
+    Tests simple add.
+
+    """
+
+    retval = dictcache_obj.add("test_key",123)
+    assert retval == 123
+    assert dictcache_obj.get("test_key") == 123
+
+
+def test_add_same_key(dictcache_obj):
+    """
+    Tests if adding the same key with a new value doesn't do anything.
+
+    """
+
+    retval = dictcache_obj.add("test_key",123)
+    assert retval == 123
+    dictcache_obj.add("test_key", 456)
+    assert dictcache_obj.get("test_key") == 123
+    assert dictcache_obj.size() == 1
+
+
+def test_cache_capacity(dictcache_obj):
+    """
+    Tests if the cache maintains the set capacity.
+
+    """
+
+    # overfill the cache
+    for x in range(1100):
+        dictcache_obj.add(f"key_{x}", f"value_{x}")
+
+    # check if the size was maintained
+    assert dictcache_obj.size() == 1000
+    assert len(dictcache_obj.container) == 1000
+    assert len(dictcache_obj.sortedkeys) == 1000
+
+    # check if the first 100 keys were removed as expected
+    for x in range(100):
+        assert dictcache_obj.get(f"key_{x}") is None
+
+    # check if the next 1000 keys are as expected
+    for x in range(100,1100):
+        assert dictcache_obj.get(f"key_{x}") == f"value_{x}"
+
+
+def test_cache_delete(dictcache_obj):
+    """
+    Tests if the cache deletes things correctly.
+
+    """
+
+    for x in range(1000):
+        dictcache_obj.add(f"key_{x}", f"value_{x}", ttl=10.0)
+
+    for x in range(1000):
+        dictcache_obj.delete(f"key_{x}")
+
+    assert dictcache_obj.size() == 0
+    assert len(dictcache_obj.container) == 0
+    assert len(dictcache_obj.sortedkeys) == 0
+    assert len(dictcache_obj.expireable_key_ttls) == 0
+
+
+def test_cache_flush(dictcache_obj):
+    """
+    Tests if the cache flushes correctly.
+
+    """
+
+    for x in range(1100):
+        dictcache_obj.add(f"key_{x}", f"value_{x}", ttl=10.0)
+
+    # check if the size was maintained
+    assert dictcache_obj.size() == 1000
+    assert len(dictcache_obj.container) == 1000
+    assert len(dictcache_obj.sortedkeys) == 1000
+
+    dictcache_obj.flush()
+    assert dictcache_obj.size() == 0
+    assert len(dictcache_obj.container) == 0
+    assert len(dictcache_obj.sortedkeys) == 0
+
+
+#
+# TTL tests
+#
+
+def test_add_key_with_ttl(dictcache_obj):
+    """
+    Tests add with key TTL.
+
+    """
+
+    add_time = time.time()
+    retval = dictcache_obj.add("test_key", 123, ttl=1.0)
+    assert retval == 123
+
+    keyval, keytime, keyttl = dictcache_obj.get("test_key", time_and_ttl=True)
+    assert keyval == 123
+    assert keyttl == 1.0
+    assert keytime == pytest.approx(add_time, rel=1.0e-3)
+
+    time.sleep(1.5)
+    assert dictcache_obj.get("test_key") is None
+    assert dictcache_obj.size() == 0
+
+
+def test_set_key(dictcache_obj):
+    """
+    Tests setting a key to a new value.
+
+    Tests setting a non-existent key with add_ifnotexists=True adds the key.
+
+    Tests setting a non-existent key with add_ifnotexists=False does nothing.
+
+    """
+
+    retval = dictcache_obj.add("test_key", 123)
+    assert retval == 123
+
+    dictcache_obj.set("test_key", "hello-world!")
+    assert dictcache_obj.get("test_key") == "hello-world!"
+
+    dictcache_obj.set("another_test_key", "hello-world-this-is-new")
+    assert dictcache_obj.get("another_test_key") == "hello-world-this-is-new"
+
+    dictcache_obj.set("one_more_test_key",
+                      "hello-world-this-should-fail",
+                      add_ifnotexists=False)
+    assert dictcache_obj.get("one_more_test_key") is None
+
+
+def test_set_key_ttl(dictcache_obj):
+    """
+    Tests if setting a key's TTL works.
+
+    """
+
+    add_time = time.time()
+    retval = dictcache_obj.add("test_key", 123, ttl=2.0)
+    assert retval == 123
+
+    # test if setting a key TTL to a new value works
+    dictcache_obj.set("test_key", 456, ttl=5.0)
+    keyval, keytime, keyttl = dictcache_obj.get("test_key", time_and_ttl=True)
+    assert keyval == 456
+    assert keyttl == 5.0
+    assert keytime == pytest.approx(add_time, rel=1.0e-3)
+
+    time.sleep(4.0)
+    assert dictcache_obj.get("test_key") == 456
+
+    time.sleep(2.0)
+    assert dictcache_obj.get("test_key") is None
+
+    # check if we can set ttl < 0
+    with pytest.raises(ValueError, match="Can't set ttl < 0"):
+        dictcache_obj.add("test_key_bad_ttl", 123, ttl=-10)
+
+
+def test_set_key_persistent(dictcache_obj):
+    """
+    Tests if setting a key's TTL to None makes it persistent.
+
+    """
+
+    add_time = time.time()
+    retval = dictcache_obj.add("test_key", 123, ttl=2.0)
+    assert retval == 123
+
+    # test if setting an expireable key's TTL to None makes it persistent
+    dictcache_obj.set("test_key", 456, ttl=None)
+    keyval, keytime, keyttl = dictcache_obj.get("test_key", time_and_ttl=True)
+    assert keyval == 456
+    assert keyttl is None
+    assert keytime == pytest.approx(add_time, rel=1.0e-3)
+
+    time.sleep(3.0)
+    assert dictcache_obj.get("test_key") == 456
+
+
+def test_set_key_expireable(dictcache_obj):
+    """
+    Tests if setting a key's TTL from None to a time val makes it expireable.
+
+    """
+
+    add_time = time.time()
+    retval = dictcache_obj.add("test_key", 123, ttl=None)
+    assert retval == 123
+
+    # test if setting an expireable key's TTL to None makes it expireable
+    dictcache_obj.set("test_key", 456, ttl=2.0)
+    keyval, keytime, keyttl = dictcache_obj.get("test_key", time_and_ttl=True)
+    assert keyval == 456
+    assert keyttl == 2.0
+    assert keytime == pytest.approx(add_time, rel=1.0e-3)
+
+    time.sleep(3.0)
+    assert dictcache_obj.get("test_key") is None
+
+
+#
+# counter key
+#
+
+def test_counterkey_increment(dictcache_obj):
+    """
+    Tests if a counter key is incremented correctly.
+
+    """
+
+    count = dictcache_obj.counter_increment("test_key")
+
+    assert count == 1
+
+    for _ in range(99):
+        dictcache_obj.counter_increment("test_key")
+
+    assert dictcache_obj.counter_get("test_key") == 100
+
+
+def test_counterkey_decrement(dictcache_obj):
+    """
+    Tests if a counter key is decremented correctly.
+
+    """
+
+    count = dictcache_obj.counter_increment("test_key")
+
+    assert count == 1
+
+    for _ in range(99):
+        dictcache_obj.counter_increment("test_key")
+
+    assert dictcache_obj.counter_get("test_key") == 100
+
+    for _ in range(99):
+        dictcache_obj.counter_decrement("test_key")
+
+    assert dictcache_obj.counter_get("test_key") == 1
+
+    # test that the key is deleted when the last decrement brings the counter to
+    # zero
+    lastval = dictcache_obj.counter_decrement("test_key")
+    assert lastval == 0
+    assert dictcache_obj.counter_get("test_key") == 0
+    assert dictcache_obj.get("test_key-dictcache-counterkey") is None
+
+
+def test_counterkey_addset(dictcache_obj):
+    """
+    Tests if a counter key can be added/set at a specific values.
+
+    """
+
+    count = dictcache_obj.counter_add("test_key",100)
+
+    assert count == 100
+    assert dictcache_obj.counter_get("test_key") == 100
+    assert dictcache_obj.get("test_key-dictcache-counterkey") == 100
+
+    count = dictcache_obj.counter_set("test_key",50)
+    assert count == 50
+    assert dictcache_obj.counter_get("test_key") == 50
+    assert dictcache_obj.get("test_key-dictcache-counterkey") == 50
+
+
+def test_counterkey_rate(dictcache_obj):
+    """
+    Tests if a counter key rate is calculated correctly.
+
+    """
+
+    total_time = 0.0
+    time_step = 0.01
+
+    start_time = time.time()
+    for _ in range(100):
+        dictcache_obj.counter_increment("test_key")
+        time.sleep(time_step)
+        total_time = total_time + time_step
+    end_time = time.time()
+
+    (rate, currval, initval, currtime, inittime) = (
+        dictcache_obj.counter_rate("test_key", 1.0, return_allinfo=True)
+    )
+    assert rate == pytest.approx((100-1)/((end_time - start_time)/1.0),
+                                 rel=1.0e-3)
+
+    # now check decreasing rates
+    dictcache_obj.counter_add("test_key_two", 101)
+
+    total_time = 0.0
+
+    start_time = time.time()
+    for _ in range(100):
+        dictcache_obj.counter_decrement("test_key_two")
+        time.sleep(time_step)
+        total_time = total_time + time_step
+    end_time = time.time()
+
+    (rate, currval, initval, currtime, inittime) = (
+        dictcache_obj.counter_rate("test_key_two", 1.0, return_allinfo=True)
+    )
+    expected_rate = abs((1-101)/((end_time - start_time)/1.0))
+    assert rate == pytest.approx(expected_rate, rel=1.0e-3)

--- a/authnzerver/tests/test_server_ratelimits.py
+++ b/authnzerver/tests/test_server_ratelimits.py
@@ -121,8 +121,9 @@ def test_ratelimits(monkeypatch, tmpdir):
         # now check if we have about the right number of successful requests
         # should be around 150 (max burst allowed) after which we get all 429s
         respcounter = Counter(resplist)
-        assert respcounter[200]/nreqs == approx(150/nreqs, rel=0.01)
-        assert respcounter[429]/nreqs == approx(150/nreqs, rel=0.01)
+        print(respcounter)
+        assert respcounter[200]/nreqs == approx(150/nreqs, rel=1.0e-3)
+        assert respcounter[429]/nreqs == approx(150/nreqs, rel=1.0e-3)
 
         #
         # kill the server at the end


### PR DESCRIPTION
This PR adds the following:

- key TTLs so we can have expiring keys
- tests for various dictcache functions
- various bugfixes for issues found by these tests
- a more consistent counter-key API
